### PR TITLE
Retained attribute

### DIFF
--- a/src/root-state.coffee.md
+++ b/src/root-state.coffee.md
@@ -21,7 +21,7 @@ of **transitions** that traverse its **state tree**.
       { env, hasOwn, trim, type, isEmpty, isArray } = O
       { slice } = Array::
 
-      { VIRTUAL, ABSTRACT, CONCLUSIVE, FINAL } = this
+      { VIRTUAL, ABSTRACT, CONCLUSIVE, FINAL, RETAINED } = this
       { VIA_NONE, VIA_PROTO } = this
 
 
@@ -260,6 +260,12 @@ Extract `args` from `options` and resolve `options` to an object if necessary.
           else options.args
           args = slice.call args if args?
 
+If `target` is a `retained` state, restore its currency by redirecting to its
+retained internal substate.
+
+        if target.attributes & RETAINED
+          target = retainee if retainee = target.query target._.retaineePath
+
 A transition cannot target an abstract state directly, so `target` must be
 reassigned to the appropriate concrete substate.
 
@@ -327,6 +333,8 @@ Walk up to the top of the domain, emitting `exit` events for each state along
 the way.
 
         s = source; while transition and s isnt domain
+          if s.attributes & RETAINED
+            s._.retaineePath = transition.origin.path()
           s.emit 'exit', eventArgs, VIA_PROTO
           transition.superstate = s = s.superstate
           @_transition = transition = null if transition.aborted

--- a/src/state-metaobject.coffee.md
+++ b/src/state-metaobject.coffee.md
@@ -27,6 +27,10 @@ The host `State`s intrinsic contents.
         @substates      = null
         @transitions    = null
 
+A `retained` state will store a path to its retained internal substate here.
+
+        @retaineePath   = null
+
 If enabled, a dispatch table may be used to cache method resolutions.
 
         @__dispatch_table__ = null if useDispatchTables

--- a/test/src/attributes.test.coffee.md
+++ b/test/src/attributes.test.coffee.md
@@ -384,6 +384,40 @@
             testImmutabilityOf o.state ''
 
 
+      describe "Retained:", ->
+        class Class
+          state @::,
+            A: state 'retained',
+              AA: state 'initial'
+              AB: state
+            B: state
+
+        it "initializes to own state", ->
+          o = new Class
+          AA = o.state()
+          expect( AA.name ).to.equal 'AA'
+          expect( AA.owner ).to.equal o
+          expect( AA.superstate.owner ).to.equal o
+          expect( o.state('AA') ).to.equal AA
+
+        it "applies the retained attribute", ->
+          o = new Class
+          expect( o.state('A').isRetained() ).to.equal yes
+
+        it "autorealizes the retained state", ->
+          o = new Class
+          expect( o.state('A').isVirtual() ).to.equal no
+
+        it "stores retainee path upon exit", ->
+          o = new Class
+          o.state '-> B'
+          expect( o.state('A')._.retaineePath ).to.equal 'A.AA'
+
+        it "restores currency of state upon arrival", ->
+          o = new Class
+          o.state '-> B'
+          o.state '-> A'
+          expect( o.state().name ).to.equal 'AA'
 
 
 

--- a/test/src/attributes.test.coffee.md
+++ b/test/src/attributes.test.coffee.md
@@ -387,9 +387,9 @@
       describe "Retained:", ->
         class Class
           state @::,
-            A: state 'retained',
+            A: state 'abstract retained',
               AA: state 'initial'
-              AB: state
+              AB: state 'default'
             B: state
 
         it "initializes to own state", ->


### PR DESCRIPTION
As discussed in #11
Implements and closes #12

---

New declarable `retained` attribute allows ad-hoc construct such as this:

``` js
var owner;

state( owner = {}, 'abstract', {
  A: ( function () {
    var internalState;
    return state({

      // Redirect an incoming transition to the retained internal state
      enter: function ( transition ) { transition.go( internalState ); },

      // Remember which internal state was current and retain that reference
      exit: function ( transition ) { internalState = transition.origin; },

      AA: state({}),
      AB: state({})
    });
  }() ),
  B: state
});
```

to be reduced to this:

``` js
state( owner = {}, 'abstract', {
  A: state( 'retained', {
    AA: state,
    AB: state
  }),
  B: state
});
```

where both cases exhibit:

``` js
owner.state('-> AB');    // AB will be retained on exit from A
owner.state('-> B');     // exited A; A retains AB as its internal currency
owner.state('-> A');     // transition back to A will be redirected to AB

owner.state().is('AB');  // >>> true
```

and the newer form also works across prototypes/protostates.
